### PR TITLE
Fixing issue with two consecutive double quotes in strings

### DIFF
--- a/const.py
+++ b/const.py
@@ -27,7 +27,7 @@ variable_name_ex = "toto"
 regex_rand_var = '\[rdm::([0-9]+)\](\w*)' #regex that select the name of the variable, after the delimiter and the length
 regex_rand_del = '\[rdm::[0-9]+\]' #regex should select only the delimiter
 
-regex_defaut_string = '[\'\"](.+?)[\'\"]' #Regex that select all string except the one follow by exception string
+regex_defaut_string = '"((?:""|[^"])*)"' #Regex selecting all strings in double quotes (including two consecutives double quotes)
 regex_exclude_string_del = '\[!!\]' #The exclusion is to avoid vba string that could finish with exclude characters.
 exclude_mark = '[!!]'
 

--- a/inc/classes.py
+++ b/inc/classes.py
@@ -317,7 +317,7 @@ class Enc_VBA_XOR:
         vba_strings = list(set(re.findall(regex_defaut_string, self.vba)))
         for strings in vba_strings:
             ciphered_string = ""
-            if exclude_mark not in strings:
+            if exclude_mark not in strings and strings != "":
 				for i in range(len(strings)):
 					ciphered_string += str((ord(strings[i]) ^ ord(self.key[self.n+i])))+","
 					if i % 20 == 0 and i != 0 and i != len(strings) - 1:


### PR DESCRIPTION
Fixing issue opened by telltell3 : string obfuscation messing up when string with 2 consecutive double quotes (str = "test123 "" 456test" : this is how vba is escaping double quote in a string). Regex is now
more precise and including this case.